### PR TITLE
GameObjectInspector : simulate prefab menu

### DIFF
--- a/PlaygroundProject/Assets/UnityPlayground/_DONT_USE/Scripts/Editor/DefaultComponents/GameObjectInspector.cs
+++ b/PlaygroundProject/Assets/UnityPlayground/_DONT_USE/Scripts/Editor/DefaultComponents/GameObjectInspector.cs
@@ -97,7 +97,28 @@ public class TestScriptInspector : Editor {
 				}
 			GUILayout.EndHorizontal();
 
-		GUILayout.EndVertical();
+            //Prefab
+            Object prefabParent = PrefabUtility.GetPrefabParent(Selection.activeGameObject);
+            if (null != prefabParent) {
+                GUILayout.Space(5);
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Prefab", GUILayout.ExpandWidth(false));
+                if (GUILayout.Button("Select", EditorStyles.miniButtonLeft)) {
+                    Selection.activeObject = prefabParent;
+                    EditorGUIUtility.PingObject(prefabParent);
+                }
+                if (GUILayout.Button("Revert", EditorStyles.miniButtonMid)) {
+                    PrefabUtility.RevertPrefabInstance(Selection.activeGameObject);
+                }
+                if (GUILayout.Button("Apply", EditorStyles.miniButtonRight)) {
+                    PrefabUtility.ReplacePrefab(Selection.activeGameObject, PrefabUtility.GetPrefabParent(Selection.activeGameObject), ReplacePrefabOptions.ConnectToPrefab);
+                }
+
+                GUILayout.EndHorizontal();
+            }
+
+        GUILayout.EndVertical();
 
 		serializedObject.ApplyModifiedProperties();
 		


### PR DESCRIPTION
Hello,
When I tried to play with the playground project, I've been stuck when i wanted to modify my prefabs (objects to spawn for example) from the Hierarchy window. So... I've recreated the prefab menu from default Unity editor to apply prefab directly from the inspector. :D

![chrome_2018-04-13_21-16-45](https://user-images.githubusercontent.com/3427268/38754244-4754e68e-3f61-11e8-86d8-3b23637ba01b.png)

Tell me if this is something you would like to integrate for the playground project. Prefabs could be confusing for beginners, but this is also a very important concept in Unity. Anyway, this is something I wanted for my students, maybe you want it for yours.

Cheers !