### PR TITLE
Fixed FollowTarget Issue

### DIFF
--- a/PlaygroundProject/Assets/UnityPlayground/Scripts/Movement/FollowTarget.cs
+++ b/PlaygroundProject/Assets/UnityPlayground/Scripts/Movement/FollowTarget.cs
@@ -21,13 +21,14 @@ public class FollowTarget : Physics2DObject
 	// FixedUpdate is called once per frame
 	void FixedUpdate ()
 	{
-		//Move towards the target
-		rigidbody2D.MovePosition(Vector2.Lerp(transform.position, target.position, Time.fixedDeltaTime * speed));
-
 		//look towards the target
 		if(lookAtTarget)
 		{
 			Utils.SetAxisTowards(useSide, transform, target.position - transform.position);
 		}
+		
+		//Move towards the target
+		rigidbody2D.MovePosition(Vector2.Lerp(transform.position, target.position, Time.fixedDeltaTime * speed));
+
 	}
 }


### PR DESCRIPTION
Changed the order in which the functions are called. This way the rotation is updated before we move.

Fixes this issue -> https://github.com/UnityTechnologies/PlaygroundProject/issues/17